### PR TITLE
Add support for OpenSearch Service dedicated master nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Pair this pacakge with [@nasa-gcn/architect-functions-search](https://github.com
         instanceType t3.small.search
         instanceCount 2
         availabilityZoneCount 2
+        # dedicatedMasterCount is optional; if zero or undefined, dedicated
+        # master nodes are disabled.
+        dedicatedMasterCount 3
+        dedicatedMasterType t3.small.search
 
 4.  Optionally, create a file called `sandbox-search.json` or `sandbox-search.js` in your project and populate it with sample data to be passed to [`client.bulk()`](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/bulk_examples.html). Here are some examples.
 

--- a/service.ts
+++ b/service.ts
@@ -8,6 +8,8 @@
 
 export function cloudformationResources({
   availabilityZoneCount,
+  dedicatedMasterCount,
+  dedicatedMasterType,
   instanceCount,
   instanceType,
   volumeSize,
@@ -22,6 +24,16 @@ export function cloudformationResources({
   const InstanceCount = parseInt(instanceCount)
   const VolumeSize = parseInt(volumeSize)
   const ZoneAwarenessEnabled = AvailabilityZoneCount > 1
+
+  const DedicatedMasterCount =
+    (dedicatedMasterCount && parseInt(dedicatedMasterCount)) || undefined
+  const DedicatedMasterEnabled = Boolean(DedicatedMasterCount)
+  const DedicatedMasterType = dedicatedMasterType
+  if (DedicatedMasterEnabled && !DedicatedMasterType) {
+    throw new Error(
+      'dedicatedMasterType must be defined because dedicateMasterCount > 0'
+    )
+  }
 
   return {
     OpenSearchServiceDomain: {
@@ -39,6 +51,9 @@ export function cloudformationResources({
           ],
         },
         ClusterConfig: {
+          DedicatedMasterCount,
+          DedicatedMasterEnabled,
+          DedicatedMasterType,
           InstanceType: instanceType,
           InstanceCount,
           ZoneAwarenessEnabled,


### PR DESCRIPTION
Dedicated master nodes are required for software upgrades without downtime. See documentation:

https://docs.aws.amazon.com/opensearch-service/latest/developerguide/version-migration.html