### PR TITLE
Support either ElasticSearch or OpenSearch in sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is a [plugin](https://arc.codes/docs/en/guides/plugins/overview) for [Architect](https://arc.codes/) that provisions managed [Amazon OpenSearch](https://aws.amazon.com/opensearch-service/) for the application.
 
-When you are using Architect's [sandbox](https://arc.codes/docs/en/reference/cli/sandbox) mode, the plugin [downloads and runs OpenSearch locally](https://opensearch.org/downloads.html#opensearch).
+When you are using Architect's [sandbox](https://arc.codes/docs/en/reference/cli/sandbox) mode, the plugin [downloads and runs Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html#elasticsearch-install-packages) or [OpenSearch](https://opensearch.org/downloads.html#opensearch) locally.
 
 Pair this pacakge with [@nasa-gcn/architect-functions-search](https://github.com/nasa-gcn/architect-functions-search) to connect to the service from your Node.js Lambda function code.
 
@@ -30,6 +30,8 @@ Pair this pacakge with [@nasa-gcn/architect-functions-search](https://github.com
         # master nodes are disabled.
         dedicatedMasterCount 3
         dedicatedMasterType t3.small.search
+        # Use OpenSearch in sandbox mode; default is Elasticsearch.
+        sandboxEngine opensearch
 
 4.  Optionally, create a file called `sandbox-search.json` or `sandbox-search.js` in your project and populate it with sample data to be passed to [`client.bulk()`](https://github.com/opensearch-project/opensearch-js/blob/main/guides/bulk.md). Here are some examples.
 

--- a/engines.ts
+++ b/engines.ts
@@ -1,0 +1,60 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type SandboxEngine = 'elasticsearch' | 'opensearch'
+
+export const manifest = [
+  {
+    engine: 'elasticsearch',
+    type: 'Linux',
+    arch: 'x64',
+    url: 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.6.2-linux-x86_64.tar.gz',
+  },
+  {
+    engine: 'elasticsearch',
+    type: 'Linux',
+    arch: 'arm64',
+    url: 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.6.2-linux-aarch64.tar.gz',
+  },
+  {
+    engine: 'elasticsearch',
+    type: 'Darwin',
+    arch: 'x64',
+    url: 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.6.2-darwin-x86_64.tar.gz',
+  },
+  {
+    engine: 'elasticsearch',
+    type: 'Darwin',
+    arch: 'arm64',
+    url: 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.6.2-darwin-aarch64.tar.gz',
+  },
+  {
+    engine: 'elasticsearch',
+    type: 'Windows_NT',
+    arch: 'x64',
+    url: 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.6.2-windows-x86_64.zip',
+  },
+  {
+    engine: 'opensearch',
+    type: 'Linux',
+    arch: 'x64',
+    url: 'https://artifacts.opensearch.org/releases/bundle/opensearch/2.11.0/opensearch-2.11.0-linux-x64.tar.gz',
+  },
+  {
+    engine: 'opensearch',
+    type: 'Linux',
+    arch: 'arm64',
+    url: 'https://artifacts.opensearch.org/releases/bundle/opensearch/2.11.0/opensearch-2.11.0-linux-arm64.tar.gz',
+  },
+  {
+    engine: 'opensearch',
+    type: 'Windows_NT',
+    arch: 'x64',
+    url: 'https://artifacts.opensearch.org/releases/bundle/opensearch/2.11.0/opensearch-2.11.0-windows-x64.zip',
+  },
+]

--- a/index.ts
+++ b/index.ts
@@ -68,8 +68,15 @@ export const deploy = {
 
 let local: LocalSearch
 
+function getEngine(name?: string) {
+  if (name?.toLowerCase() === 'opensearch') return 'opensearch'
+  else return 'elasticsearch'
+}
+
 export const sandbox = {
   async start({
+    // @ts-expect-error: The Architect plugins API has no type definitions.
+    arc,
     inventory: {
       inv: {
         // @ts-expect-error: The Architect plugins API has no type definitions.
@@ -77,7 +84,8 @@ export const sandbox = {
       },
     },
   }) {
-    local = await launch({})
+    const engine = getEngine(getConfig(arc).sandboxEngine)
+    local = await launch({ engine })
     await populate(cwd, { node: local.url })
   },
   async end() {


### PR DESCRIPTION
OpenSearch has been built for fewer platforms than Elasticsearch. Support either OpenSearch or Elasticsearch depending on the configuration in the Architect project manifest.

Note: merge #27 and #28 first.