### PR TITLE
Rename class LocalOpenSearch to LocalSearch

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@
  */
 
 import { launch } from './run.js'
-import type { LocalOpenSearch } from './run.js'
+import type { LocalSearch } from './run.js'
 import { populate } from './data.js'
 import {
   cloudformationResources as serverlessCloudformationResources,
@@ -58,7 +58,7 @@ export const deploy = {
   },
 }
 
-let local: LocalOpenSearch
+let local: LocalSearch
 
 export const sandbox = {
   async start({

--- a/run.ts
+++ b/run.ts
@@ -21,7 +21,7 @@ import {
 import { pipeline } from 'stream/promises'
 import { createReadStream } from 'fs'
 
-export class LocalOpenSearch {
+export class LocalSearch {
   private readonly child!: ChildProcess
   private readonly tempDir!: string
   readonly port!: number
@@ -93,8 +93,6 @@ export class LocalOpenSearch {
   }
 }
 
-export async function launch(
-  ...args: Parameters<typeof LocalOpenSearch.launch>
-) {
-  return await LocalOpenSearch.launch(...args)
+export async function launch(...args: Parameters<typeof LocalSearch.launch>) {
+  return await LocalSearch.launch(...args)
 }


### PR DESCRIPTION
We're going to support either Elasticsearch or OpenSearch in sandbox mode. Rename the class to reflect that.