### PR TITLE
Support serverless deployments with `@search` pragma

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -32,12 +32,20 @@ function toCollectionName(name: string) {
     .slice(0, 32)
 }
 
+function getConfig(arc: {
+  search?: string[][]
+}): Record<string, string | undefined> {
+  if (arc.search) return Object.fromEntries(arc.search)
+  else return {}
+}
+
 export const deploy = {
   // @ts-expect-error: The Architect plugins API has no type definitions.
   start({ cloudformation, inventory, arc, stage }) {
     let resources
-    if (arc.search) {
-      resources = serviceCloudformationResources(Object.fromEntries(arc.search))
+    const config = getConfig(arc)
+    if (config.availabilityZoneCount) {
+      resources = serviceCloudformationResources(config)
     } else {
       const { app } = inventory.inv
       const collectionName = toCollectionName(`${app}-${stage}`)


### PR DESCRIPTION
We're going to add some more configs to the `@search` pragma to adjust sandbox settings, so we can no longer use the presence or absence of the pragma itself to determine whether to deploy to service mode or serverless mode.

Instead, check whether we are in service or serverless mode by looking for one of the config keys that is required for service mode.