### PR TITLE
Fall back to Docker for sandbox mode (Docker CLI version)

### DIFF
--- a/install.ts
+++ b/install.ts
@@ -30,9 +30,10 @@ export async function install(engine: SandboxEngine) {
       entry.engine === engine && entry.arch === arch && entry.type === type
   )?.url
   if (!url) {
-    throw new Error(
+    console.warn(
       `No ${engine} binary is available for your OS type (${type}) and architecture (${arch}).`
     )
+    return
   }
 
   const archiveFilename = posix


### PR DESCRIPTION
OpenSearch isn't yet built for macOS (see https://github.com/opensearch-project/opensearch-build/issues/38), the platform that half of our developers use. Fall back to Docker for sandbox mode if Elasticsearch or OpenSearch is not built for the user's platform.

Note: merge #26 first.