### PR TITLE
Change run.ts to wait for port to be ready.

### DIFF
--- a/run.ts
+++ b/run.ts
@@ -128,7 +128,7 @@ export async function launch({
     : launchDocker(props))
 
   try {
-    Promise.race([
+    await Promise.race([
       waitPort({ port, protocol: 'http' }),
       neverResolve(waitUntilStopped()),
     ])


### PR DESCRIPTION
Add an await operator to wait for server to be ready before client makes requests. Prevents "ConnectionError: connect ECONNREFUSED ::1:9200" error