### PR TITLE
add docker heartbeat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
-*.js
+index.js
 *.tgz

--- a/heartbeat.js
+++ b/heartbeat.js
@@ -1,49 +1,48 @@
-import { exec } from 'child_process'
+import { exec } from "child_process";
 
-const pidInput = process.argv[2]
-const containerName = process.argv[3]
-let healthy = true
-let currentIntervalId
+const pidInput = process.argv[2];
+const containerName = process.argv[3];
+let healthy = true;
+let currentIntervalId;
 
 function checkProcessStatus(pid) {
   return new Promise((resolve) => {
-    if (process.platform === 'win32') {
+    if (process.platform === "win32") {
       exec(`tasklist /FI "PID eq ${pid}"`, (err, stdout) => {
         if (err) {
-          resolve({ pid, running: false })
+          resolve({ pid, running: false });
         }
-        resolve({ pid, running: stdout.includes(`pid: ${pid}`) })
-      })
+        resolve({ pid, running: stdout.includes(`pid: ${pid}`) });
+      });
     } else {
       exec(`ps -p ${pid}`, (error, stdout) => {
         if (error) {
-          resolve({ pid, running: false })
+          resolve({ pid, running: false });
         } else {
-          resolve({ pid, running: stdout.includes(pid.toString()) })
+          resolve({ pid, running: stdout.includes(pid.toString()) });
         }
-      })
+      });
     }
-  })
+  });
 }
 
 async function monitorProcess(pid, container) {
   try {
-    const status = await checkProcessStatus(pid)
-    if (!status.running){
-      exec(`docker stop ${container}`)
-      healthy = false
-      process.exit(0)
+    const status = await checkProcessStatus(pid);
+    if (!status.running) {
+      exec(`docker stop ${container}`);
+      healthy = false;
+      process.exit(0);
     }
   } catch (error) {
-    console.error('Error checking process status:', error)
+    console.error("Error checking process status:", error);
   }
 }
 
 currentIntervalId = setInterval(() => {
-  monitorProcess(parseInt(pidInput), containerName)
-}, 10000) // ping every 10 seconds
-process.stdout.write('\u0007')
+  monitorProcess(parseInt(pidInput), containerName);
+}, 10000); // ping every 10 seconds
 
-if (!healthy){
-  clearInterval(currentIntervalId)
+if (!healthy) {
+  clearInterval(currentIntervalId);
 }

--- a/heartbeat.js
+++ b/heartbeat.js
@@ -1,41 +1,49 @@
-import { exec } from 'child_process';
+import { exec } from 'child_process'
 
-const pidInput = process.argv[2];
+const pidInput = process.argv[2]
 const containerName = process.argv[3]
 let healthy = true
 let currentIntervalId
 
 function checkProcessStatus(pid) {
   return new Promise((resolve) => {
-    exec(`ps -p ${pid}`, (error, stdout) => {
-      if (error) {
-        resolve({ pid, running: false });
-      } else {
-        const processRunning = stdout.includes(pid.toString());
-        resolve({ pid, running: processRunning });
-      }
-    });
-  });
+    if (process.platform === 'win32') {
+      exec(`tasklist /FI "PID eq ${pid}"`, (err, stdout) => {
+        if (err) {
+          resolve({ pid, running: false })
+        }
+        resolve({ pid, running: stdout.includes(`pid: ${pid}`) })
+      })
+    } else {
+      exec(`ps -p ${pid}`, (error, stdout) => {
+        if (error) {
+          resolve({ pid, running: false })
+        } else {
+          resolve({ pid, running: stdout.includes(pid.toString()) })
+        }
+      })
+    }
+  })
 }
 
 async function monitorProcess(pid, container) {
   try {
-    const status = await checkProcessStatus(pid);
+    const status = await checkProcessStatus(pid)
     if (!status.running){
       exec(`docker stop ${container}`)
       healthy = false
       process.exit(0)
     }
   } catch (error) {
-    console.error('Error checking process status:', error);
+    console.error('Error checking process status:', error)
   }
 }
 
 currentIntervalId = setInterval(() => {
-  monitorProcess(parseInt(pidInput), containerName);
-}, 10000); // ping every 10 seconds
+  monitorProcess(parseInt(pidInput), containerName)
+}, 10000) // ping every 10 seconds
 process.stdout.write('\u0007')
 
 if (!healthy){
-  clearInterval(currentIntervalId);
+  clearInterval(currentIntervalId)
 }

--- a/heartbeat.js
+++ b/heartbeat.js
@@ -1,0 +1,41 @@
+import { exec } from 'child_process';
+
+const pidInput = process.argv[2];
+const containerName = process.argv[3]
+let healthy = true
+let currentIntervalId
+
+function checkProcessStatus(pid) {
+  return new Promise((resolve) => {
+    exec(`ps -p ${pid}`, (error, stdout) => {
+      if (error) {
+        resolve({ pid, running: false });
+      } else {
+        const processRunning = stdout.includes(pid.toString());
+        resolve({ pid, running: processRunning });
+      }
+    });
+  });
+}
+
+async function monitorProcess(pid, container) {
+  try {
+    const status = await checkProcessStatus(pid);
+    if (!status.running){
+      exec(`docker stop ${container}`)
+      healthy = false
+      process.exit(0)
+    }
+  } catch (error) {
+    console.error('Error checking process status:', error);
+  }
+}
+
+currentIntervalId = setInterval(() => {
+  monitorProcess(parseInt(pidInput), containerName);
+}, 10000); // ping every 10 seconds
+process.stdout.write('\u0007')
+
+if (!healthy){
+  clearInterval(currentIntervalId);
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   ],
   "type": "module",
   "files": [
-    "index.js"
+    "index.js",
+    "heartbeat.js"
   ],
   "scripts": {
     "prepare:husky": "husky install",


### PR DESCRIPTION
# Description
This creates a heartbeat that checks to see if the main process is still running every 10 seconds. If the main process is running, it waits another 10 seconds before checking again. If the main process is not running, it kills the docker container by id.

# Related Issue(s)
Resolves #34 

# Testing
I have just tested this locally on mac.
