### PR TITLE
Revert "Enable audit logs"

### DIFF
--- a/service.ts
+++ b/service.ts
@@ -36,21 +36,12 @@ export function cloudformationResources({
   }
 
   return {
-    OpenSearchApplicationLogGroup: {
+    OpenSearchLogGroup: {
       Type: 'AWS::Logs::LogGroup',
       Properties: {
         LogGroupName: {
           'Fn::Sub':
             '/aws/OpenSearchService/stacks/${AWS::StackName}/application-logs',
-        },
-      },
-    },
-    OpenSearchAuditLogGroup: {
-      Type: 'AWS::Logs::LogGroup',
-      Properties: {
-        LogGroupName: {
-          'Fn::Sub':
-            '/aws/OpenSearchService/stacks/${AWS::StackName}/audit-logs',
         },
       },
     },
@@ -67,10 +58,7 @@ export function cloudformationResources({
                 Effect: 'Allow',
                 Principal: { Service: 'es.amazonaws.com' },
                 Action: ['logs:PutLogEvents', 'logs:CreateLogStream'],
-                Resource: [
-                  { 'Fn::GetAtt': ['OpenSearchAuditLogGroup', 'Arn'] },
-                  { 'Fn::GetAtt': ['OpenSearchApplicationLogGroup', 'Arn'] },
-                ],
+                Resource: { 'Fn::GetAtt': ['OpenSearchLogGroup', 'Arn'] },
               },
             ],
           },
@@ -110,15 +98,9 @@ export function cloudformationResources({
         EncryptionAtRestOptions: { Enabled: true },
         IPAddressType: 'dualstack',
         LogPublishingOptions: {
-          AUDIT_LOGS: {
-            CloudWatchLogsLogGroupArn: {
-              'Fn::GetAtt': ['OpenSearchAuditLogGroup', 'Arn'],
-            },
-            Enabled: true,
-          },
           ES_APPLICATION_LOGS: {
             CloudWatchLogsLogGroupArn: {
-              'Fn::GetAtt': ['OpenSearchApplicationLogGroup', 'Arn'],
+              'Fn::GetAtt': ['OpenSearchLogGroup', 'Arn'],
             },
             Enabled: true,
           },


### PR DESCRIPTION
Reverts nasa-gcn/architect-plugin-search#73.

Audit logs require fine-grained access control, which we have not enabled.