### PR TITLE
Adds a fix for a EINVAL error on windows machines

### DIFF
--- a/runBinary.ts
+++ b/runBinary.ts
@@ -19,6 +19,7 @@ export const launchBinary: SearchEngineLauncherFunction<{
   console.log('Spawning', bin, ...args)
   const child = await spawn(bin, args, {
     stdio: ['ignore', 'ignore', 'inherit'],
+    shell: true,
   })
 
   return {


### PR DESCRIPTION
As part of [this](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high) update, the plugin fails to spawn child processes on windows

This adds the fix mentioned in the article linked. 

