### PR TITLE
Run esbuild on test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "prepare:husky": "husky",
-    "prepare:esbuild": "esbuild index.ts --bundle --packages=external --outfile=index.js --platform=node --format=esm --tree-shaking=true",
+    "prepare:esbuild": "esbuild __tests__/test.ts index.ts --bundle --packages=external --outdir=. --platform=node --format=esm --tree-shaking=true",
     "prepare": "run-p prepare:*",
     "test": "node --test"
   },


### PR DESCRIPTION
The tests were not even running because we weren't running esbuild on test.ts to generate test.js.