### PR TITLE
Wait until Architect prints message that sandbox has started

### DIFF
--- a/__tests__/test.ts
+++ b/__tests__/test.ts
@@ -59,7 +59,14 @@ engines.forEach((engine) =>
           cwd,
           preferLocal: true,
           forceKillAfterDelay: false,
-          stdio: 'inherit',
+          stderr: 'inherit',
+          stdout: ['inherit', 'pipe'],
+        })
+
+        return new Promise<void>((resolve) => {
+          process?.stdout?.on('data', (chunk) => {
+            if (chunk.includes('Ran Sandbox startup plugin in')) resolve()
+          })
         })
       })
 


### PR DESCRIPTION
Pause the test until the Achitect sandbox start entry point returns. This prevents the test from proceeding to kill Architect too early, and eliminates the error message:

    Error: Search engine terminated unexpectedly