### PR TITLE
Fix unit tests

### DIFF
--- a/__tests__/test.ts
+++ b/__tests__/test.ts
@@ -59,6 +59,7 @@ engines.forEach((engine) =>
           cwd,
           preferLocal: true,
           forceKillAfterDelay: false,
+          stdin: 'pipe',
           stderr: 'inherit',
           stdout: ['inherit', 'pipe'],
         })
@@ -72,6 +73,8 @@ engines.forEach((engine) =>
 
       afterEach(async () => {
         if (process) {
+          // Type Ctrl-C into Architect's stdin
+          process.stdin?.write('\u0003')
           assert.ok(process.kill(signal))
           // Make sure arc sandbox is dead
           try {

--- a/engines.ts
+++ b/engines.ts
@@ -43,18 +43,18 @@ export const manifest = [
     engine: 'opensearch',
     type: 'Linux',
     arch: 'x64',
-    url: 'https://artifacts.opensearch.org/releases/bundle/opensearch/2.11.0/opensearch-2.11.0-linux-x64.tar.gz',
+    url: 'https://artifacts.opensearch.org/releases/bundle/opensearch/2.19.1/opensearch-2.19.1-linux-x64.tar.gz',
   },
   {
     engine: 'opensearch',
     type: 'Linux',
     arch: 'arm64',
-    url: 'https://artifacts.opensearch.org/releases/bundle/opensearch/2.11.0/opensearch-2.11.0-linux-arm64.tar.gz',
+    url: 'https://artifacts.opensearch.org/releases/bundle/opensearch/2.19.1/opensearch-2.19.1-linux-arm64.tar.gz',
   },
   {
     engine: 'opensearch',
     type: 'Windows_NT',
     arch: 'x64',
-    url: 'https://artifacts.opensearch.org/releases/bundle/opensearch/2.11.0/opensearch-2.11.0-windows-x64.zip',
+    url: 'https://artifacts.opensearch.org/releases/bundle/opensearch/2.19.1/opensearch-2.19.1-windows-x64.zip',
   },
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@nasa-gcn/eslint-config-gitignore": "^0.0.2",
         "@tsconfig/node14": "^14.1.2",
         "@types/dockerode": "^3.3.23",
-        "@types/lodash": "^4.14.202",
+        "@types/lodash": "^4.17.16",
         "@types/make-fetch-happen": "^10.0.1",
         "@types/node": "^22.2.0",
         "@types/tar": "^6.1.4",
@@ -3316,10 +3316,11 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==",
-      "dev": true
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/make-fetch-happen": {
       "version": "10.0.4",
@@ -7211,7 +7212,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "make-fetch-happen": "^14.0.0",
         "rimraf": "^4.1.2",
         "tar": "^7.4.1",
+        "tree-kill": "^1.2.2",
         "unzip-stream": "^0.3.1",
         "wait-port": "^1.0.4"
       },
@@ -9698,7 +9699,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "make-fetch-happen": "^14.0.0",
     "rimraf": "^4.1.2",
     "tar": "^7.4.1",
+    "tree-kill": "^1.2.2",
     "unzip-stream": "^0.3.1",
     "wait-port": "^1.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@nasa-gcn/eslint-config-gitignore": "^0.0.2",
     "@tsconfig/node14": "^14.1.2",
     "@types/dockerode": "^3.3.23",
-    "@types/lodash": "^4.14.202",
+    "@types/lodash": "^4.17.16",
     "@types/make-fetch-happen": "^10.0.1",
     "@types/node": "^22.2.0",
     "@types/tar": "^6.1.4",

--- a/runBinary.ts
+++ b/runBinary.ts
@@ -9,6 +9,7 @@
 import treeKill from 'tree-kill'
 import { spawn, untilTerminated } from './processes.js'
 import { type SearchEngineLauncherFunction } from './run.js'
+import omit from 'lodash/omit.js'
 
 export const launchBinary: SearchEngineLauncherFunction<{
   bin: string
@@ -23,6 +24,8 @@ export const launchBinary: SearchEngineLauncherFunction<{
     // On Windows, the program must be launched in a shell because it is a .bat file. See
     // https://nodejs.org/docs/latest/api/child_process.html#spawning-bat-and-cmd-files-on-windows
     shell: process.platform === 'win32',
+    // Use bundled JVM, not system JVM, in case system JVM is too old
+    env: omit(process.env, ['JAVA_HOME']),
   })
 
   async function kill() {

--- a/runBinary.ts
+++ b/runBinary.ts
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import treeKill from 'tree-kill'
 import { spawn, untilTerminated } from './processes.js'
 import { type SearchEngineLauncherFunction } from './run.js'
 
@@ -26,7 +27,7 @@ export const launchBinary: SearchEngineLauncherFunction<{
 
   async function kill() {
     console.log('Killing child process')
-    child.kill('SIGKILL')
+    if (child.pid) treeKill(child.pid)
   }
 
   const signals = ['message', 'SIGTERM', 'SIGINT']


### PR DESCRIPTION
- When killing the Elasticsearch process, use tree-kill to kill the entire process tree.
- In the unit tests, simulate typing Ctrl-C rather than sending a signal.