### PR TITLE
Add search-index-mapping pragma and mapping function

### DIFF
--- a/data.ts
+++ b/data.ts
@@ -53,3 +53,23 @@ export async function populate(path: string, opts: ClientOptions) {
     }
   }
 }
+
+export async function createMapping(
+  index: string,
+  mappedProps: { [key: string]: string },
+  opts: ClientOptions
+) {
+  const properties: { [key: string]: { type: string } } = {}
+  Object.entries(mappedProps).forEach(([item, type]) => {
+    properties[item] = { type }
+  })
+  const client = new Client(opts)
+  await client.indices.create({
+    index,
+    body: {
+      mappings: {
+        properties,
+      },
+    },
+  })
+}

--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@ import { exists } from './paths.js'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { launch } from './run.js'
-import { populate } from './data.js'
+import { createMapping, populate } from './data.js'
 import { search as getSearchClient } from '@nasa-gcn/architect-functions-search'
 import {
   cloudformationResources as serverlessCloudformationResources,
@@ -129,6 +129,16 @@ export const sandbox = {
     const engine = getEngine(getConfig(arc).sandboxEngine)
     local = await launch({ engine })
     await executeSearchRequests(cwd)
+
+    if (arc['search-index-mapping']) {
+      for (const item of arc['search-index-mapping']) {
+        const indexName = Object.keys(item)[0]
+        await createMapping(indexName, item[indexName], {
+          node: local.url,
+        })
+      }
+    }
+
     await populate(cwd, { node: local.url })
     update.done('OpenSearch/ElasticSearch is ready')
   },


### PR DESCRIPTION
Opensearch supports the creation of mappings on an index for field types such as arrays of strings.

https://docs.opensearch.org/latest/mappings/mapping-parameters/properties/
The example usage in `app.arc`:
```
@search-index-mapping
users             # index name
  groups keyword  # `{field} {type}`
```
When new users are added to this index, opensearch would be able to use the `groups` field in filters 
See: https://github.com/nasa-gcn/gcn.nasa.gov/pull/3702