### PR TITLE
Add support for defining index templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ Pair this pacakge with [@nasa-gcn/architect-functions-search](https://github.com
             ]
         }
 
+5.  If you want to define more specific index mappings/settings, you can include `templateFile` in your `@search` section. For more details, see [Index Templates](https://docs.opensearch.org/latest/im-plugin/index-templates/).
+
+        @search
+        autoSoftwareUpdateEnabled true
+        instanceType t3.small.search
+        instanceCount 2
+        availabilityZoneCount 2
+        dedicatedMasterCount 3
+        dedicatedMasterType t3.small.search
+        offPeakWindowEnabled true
+        templateFile index-template.json
+
 ## Connecting to OpenSearch from your application
 
 In your Architect application, use the [@nasa-gcn/architect-functions-search](https://github.com/nasa-gcn/architect-functions-search) package to connect to your OpenSearch instance. To install the package, run:

--- a/data.ts
+++ b/data.ts
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { readFile } from 'node:fs/promises'
+import { access, constants, readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { Client } from '@opensearch-project/opensearch'
@@ -14,6 +14,8 @@ import type { ClientOptions } from '@opensearch-project/opensearch'
 import { exists } from './paths.js'
 import chunk from 'lodash/chunk.js'
 import { update } from './updater.js'
+import { RequestBody } from '@opensearch-project/opensearch/lib/Transport.js'
+import { search } from '@nasa-gcn/architect-functions-search'
 
 const jsonFilename = 'sandbox-search.json'
 const jsFilename = 'sandbox-search.js'
@@ -40,6 +42,43 @@ async function getData(path: string): Promise<object[]> {
     update.update(`Loaded ${result.length} search records`)
   }
   return result
+}
+
+/**
+ * Calls `client.indices.putIndexTemplate()` for each named template defined in
+ * templateFile. If `opts` are omitted, gets the opensearch client from the
+ * "@nasa-gcn/architect-functions-search" plugin.
+ *
+ * @param templateFile
+ * @param opts
+ * @returns
+ */
+export async function initializeIndices(
+  templateFile: string,
+  opts?: ClientOptions
+) {
+  try {
+    await access(templateFile, constants.R_OK)
+  } catch {
+    update.err(`File "${templateFile}" found or not readable`)
+    return
+  }
+
+  try {
+    const data = JSON.parse(await readFile(templateFile, 'utf8'))
+    const client = opts ? new Client(opts) : await search()
+    const promises = data.index_templates.map(
+      ({ name, index_template }: { name: string; index_template: unknown }) => {
+        client.indices.putIndexTemplate({
+          name,
+          body: index_template as RequestBody,
+        })
+      }
+    )
+    await Promise.all(promises)
+  } catch (error) {
+    update.err(error)
+  }
 }
 
 export async function populate(path: string, opts: ClientOptions) {

--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@ import { exists } from './paths.js'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { launch } from './run.js'
-import { populate } from './data.js'
+import { initializeIndices, populate } from './data.js'
 import { search as getSearchClient } from '@nasa-gcn/architect-functions-search'
 import {
   cloudformationResources as serverlessCloudformationResources,
@@ -102,8 +102,10 @@ export const deploy = {
     }
   },
   // @ts-expect-error: The Architect plugins API has no type definitions.
-  async end({ inventory }) {
+  async end({ inventory, arc }) {
+    const config = getConfig(arc)
     executeSearchRequests(inventory.inv._project.cwd)
+    if (config.templateFile) await initializeIndices(config.templateFile)
   },
 }
 
@@ -129,6 +131,9 @@ export const sandbox = {
     const engine = getEngine(getConfig(arc).sandboxEngine)
     local = await launch({ engine })
     await executeSearchRequests(cwd)
+    const config = getConfig(arc)
+    if (config.templateFile)
+      await initializeIndices(config.templateFile, { node: local.url })
     await populate(cwd, { node: local.url })
     update.done('OpenSearch/ElasticSearch is ready')
   },


### PR DESCRIPTION
Adds a check for `templateFile` in the `@search` pragma. 

If found, loads the template as json and calls `client.indices.putIndexTemplate()` to initialize the index definitions.

This runs in `sandbox.start` and `deploy.end`.

Updates the readme to show usage.