### PR TITLE
Match @aws-sdk/* package versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-cloudformation": "^3.1103.0",
+        "@aws-sdk/client-cloudformation": "^3.895.0",
         "@nasa-gcn/architect-functions-search": "^1.1.1",
         "@nasa-gcn/architect-plugin-utils": "^0.5.2",
         "@opensearch-project/opensearch": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@aws-sdk/client-cloudformation": "^3.1103.0",
+    "@aws-sdk/client-cloudformation": "^3.895.0",
     "@nasa-gcn/architect-functions-search": "^1.1.1",
     "@nasa-gcn/architect-plugin-utils": "^0.5.2",
     "@opensearch-project/opensearch": "^2.2.0",


### PR DESCRIPTION
This is the version that is preinstalled in the AWS Lambda Node.js 24 runtime images.